### PR TITLE
Mol 63 add pdbqt to pdb conversion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:19.10
 
 # Update Ubuntu Software Repo and install curl
 RUN apt-get update && apt-get install curl --yes

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ Request body parameters
 
 | Parameter | Type | Function |
 |:----------|:-----|:---------|
-| molecule_n | form data | A .pdb file to be converted to .pdbqt format. Note that any number of molecules can be given, keyed "molecule_1," "molecule_2," etc.|
+| molecule_n | form data | A file to be converted. By default a .pdb file is expected, and will be converted to a .pdbqt file. Note that any number of molecules can be given, keyed "molecule_1," "molecule_2," etc.|
+| toPDB | form data | If true, converts the input .pdbqt file to .pdb format. A single file will be returned containing both molecules if a .pdb macromolecule and a .pdbqt ligand file that resulted from a docking operation are given.|
 
 Output
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ This briefly summarizes all API endpoints.
 
 | HTTP Method | Endpoint | Function |
 |:------------|:---------|:---------|
-| POST | [/v1/obabel](#post-obabel) | Submits .pdb files for conversion to pdbqt file format |
+| POST | [/v1/obabel/toPDB](#post-pdb) | Submits .pdbqt files for combination and conversion to pdb file format |
+| POST | [/v1/obabel/toPDBQT](#post-pdbqt) | Submits files for conversion to pdbqt file format |
 | GET | [/v1/obabel/{storage_hash}](#get-obabel) | Returns a zip file of pdbqt files that were previously submitted as .pdb files |
 
 
@@ -55,21 +56,34 @@ This briefly summarizes all API endpoints.
 
 This outlines the API's endpoints, request types, and expected request parameters or JSON payload.
 
-<a name="post-obabel"></a>
-##### POST /v1/obabel
-###### Submits a number of .pdb files to Open Babel for conversion
+<a name="post-pdb"></a>
+##### POST /v1/obabel/toPDB
+###### Submits .pdbqt files for combination and conversion to pdb file format
+ 
+Request body parameters
 
+| Parameter | Type | Function |
+|:----------|:-----|:---------|
+| molecule_n | form data | A file to be converted. A .pdbqt file is expected, and will be converted to a .pdb file. Note that any number of molecules can be given, keyed "molecule_1," "molecule_2," etc. If a ligand and a macromolecule are given, they will be combined into a single output file|
+
+Output
+
+Returns a storage hash value which is used to retrieve the converted files. (status: 200)
+ 
+<a name="post-pdbqt"></a>
+##### POST /v1/obabel/toPDB
+###### Submits a number of molecule files to Open Babel for conversion to .pdbqt format
+ 
 Request body parameters
 
 | Parameter | Type | Function |
 |:----------|:-----|:---------|
 | molecule_n | form data | A file to be converted. By default a .pdb file is expected, and will be converted to a .pdbqt file. Note that any number of molecules can be given, keyed "molecule_1," "molecule_2," etc.|
-| toPDB | form data | If true, converts the input .pdbqt file to .pdb format. A single file will be returned containing both molecules if a .pdb macromolecule and a .pdbqt ligand file that resulted from a docking operation are given.|
 
 Output
 
 Returns a storage hash value which is used to retrieve the converted files. (status: 200)
-) 
+ 
 
 <a name="get-obabel"></a>
 ##### GET /v1/obabel/?storage_hash={storage_hash}

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Request body parameters
 | Parameter | Type | Function |
 |:----------|:-----|:---------|
 | molecule_n | form data | A file to be converted. A .pdbqt file is expected, and will be converted to a .pdb file. Note that any number of molecules can be given, keyed "molecule_1," "molecule_2," etc. If a ligand and a macromolecule are given, they will be combined into a single output file|
+| options | form data | String of additional options to pass to OpenBabel at runtime. Optional. |
 
 Output
 
@@ -79,6 +80,7 @@ Request body parameters
 | Parameter | Type | Function |
 |:----------|:-----|:---------|
 | molecule_n | form data | A file to be converted. By default a .pdb file is expected, and will be converted to a .pdbqt file. Note that any number of molecules can be given, keyed "molecule_1," "molecule_2," etc.|
+| options | form data | String of additional options to pass to OpenBabel at runtime. Optional. |
 
 Output
 

--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ app.get('/v1/obabel', (req, res) => {
 });
 
 app.post('/v1/obabel/toPDBQT', (req, res) => {
-  return openbabelFileConversion(req, res,'result.pdbqt',["-xr"])
+  return openbabelFileConversion(req, res,'result.pdbqt')
 });
 
 app.post('/v1/obabel/toPDB', (req, res) => {
@@ -172,9 +172,12 @@ function openbabelFileConversion(req, res, outputName, options = [], inputFileTy
       args.push(`-O${outputFilePath}`);
       
       //add all specified options to the command
-      for(let option in options){
+      for(option of options){
         args.push(option);
       }
+	  
+	  if(fields.options)
+		args.push(fields.options);
 
       try {
         obable_program = path.join(__dirname, "obabel");

--- a/index.js
+++ b/index.js
@@ -105,24 +105,21 @@ app.post('/v1/obabel', (req, res) => {
         //each field in the form whose name starts with "molecule"
         if (name.startsWith('molecule')) {
             molecule = {}
-            molecule.name = name
+            molecule.name = file.name
             molecules.push(molecule)
         }
 
-        fullPath = path.join(directoryPath, name);
+        fullPath = path.join(directoryPath, file.name);
         file.path = fullPath;
     });
     form.on('end', function() {
         try {
             //arguments for openbabel
             var args = []
-            var options = []
-            //include metadata in the file
-            args.push('-m');          
-			if('toPDB' in fields && fields['toPDB'] == "true"){
-				//set the input file type to pdbqt
-				args.push('-ipdbqt');
-			}else{
+            var options = [] 
+			
+			//does not include -i tag if the value of toPDB is true (so the molecules are combined in one file)
+			if(!('toPDB' in fields) || !(fields['toPDB'] == "true")){
 				//set the input file type to pdb (the default option)
 				args.push('-ipdb');
 			}
@@ -133,12 +130,9 @@ app.post('/v1/obabel', (req, res) => {
                 args.push('"' + molecule_path + '"');
                 
             }
-			if('toPDB' in fields && fields['toPDB']){
-				//set the output file type to pdb
-				args.push('-opdb');
-				//together these flags cause the inpur pieces to output as a single complete molecule
-				args.push('-r -c');
-			}else{
+			
+			//does not include -o tag if the value of toPDB is true (so the molecules are combined in one file)
+			if(!('toPDB' in fields) || !(fields['toPDB'])){
 				//set the output file type to pdbqt (This is the default behavior)
 				args.push('-opdbqt');
 			}

--- a/index.js
+++ b/index.js
@@ -136,6 +136,8 @@ app.post('/v1/obabel', (req, res) => {
 			if('toPDB' in fields && fields['toPDB']){
 				//set the output file type to pdb
 				args.push('-opdb');
+				//together these flags cause the inpur pieces to output as a single complete molecule
+				args.push('-r -c');
 			}else{
 				//set the output file type to pdbqt (This is the default behavior)
 				args.push('-opdbqt');

--- a/index.js
+++ b/index.js
@@ -118,10 +118,14 @@ app.post('/v1/obabel', (req, res) => {
             var args = []
             var options = []
             //include metadata in the file
-            args.push('-m');
-            //set the input file type to pdb
-            args.push('-ipdb');
-            //add each of the  
+            args.push('-m');          
+			if('toPDB' in fields && fields['toPDB'] == "true"){
+				//set the input file type to pdbqt
+				args.push('-ipdbqt');
+			}else{
+				//set the input file type to pdb (the default option)
+				args.push('-ipdb');
+			}
             for(molecule of molecules){
                 
                 molecule_path = path.join(directoryPath,molecule.name )
@@ -129,16 +133,34 @@ app.post('/v1/obabel', (req, res) => {
                 args.push('"' + molecule_path + '"');
                 
             }
-            //set the output file type to pdbqt
-            args.push('-opdbqt');
+			if('toPDB' in fields && fields['toPDB']){
+				//set the output file type to pdb
+				args.push('-opdb');
+			}else{
+				//set the output file type to pdbqt (This is the default behavior)
+				args.push('-opdbqt');
+			}
+			
+			var outputFilePath = '';
+			if('toPDB' in fields && fields['toPDB']){
+				//set the output file type to pdb
+				outputFilePath = path.join(directoryPath,'result.pdb')
+			}else{
+				//set the output file type to pdbqt (This is the default behavior)
+				outputFilePath = path.join(directoryPath,'result.pdbqt')
+			}
+			args.push(`-O${outputFilePath}`);
+            
             try {
                 obable_program = path.join(__dirname, "obabel");
 
                 options = {};
                 options.shell = true;
                 
+				console.log(args.toString())
+				
                 //execute the obabel binary
-                execFile("obabel", args, options, function(error, stdout, stderr) {
+                exec("obabel " + args.join(' '), options, function(error, stdout, stderr) {
                     
                     callback = (error) => {
                         if(!responseIsSent) {

--- a/index.js
+++ b/index.js
@@ -10,194 +10,199 @@ var archiver = require('archiver')
 
 app.use(express.json())
 app.get('/v1/obabel', (req, res) => {
-    //identifier for this particular file conversion job
-    var jobId = req.query.storage_hash;
-    //path defining the directory the file is to be saved to
-    var uploadsPath = path.join(__dirname,'uploads');
-    //the full path of the file to be saved
-    var fullPath = path.join(__dirname,"uploads", jobId);
-    //the full file path of the file to store openbabel's output text
-    var obabelOutputFilePath = path.join(fullPath,'obabel-output.txt');
-    //Keep track of whether a response has been sent to avoid sending a
-    //redundant response
-    var responseIsSent = false;
+  //identifier for this particular file conversion job
+  var jobId = req.query.storage_hash;
+  //path defining the directory the file is to be saved to
+  var uploadsPath = path.join(__dirname,'uploads');
+  //the full path of the file to be saved
+  var fullPath = path.join(__dirname,"uploads", jobId);
+  //the full file path of the file to store openbabel's output text
+  var obabelOutputFilePath = path.join(fullPath,'obabel-output.txt');
+  //Keep track of whether a response has been sent to avoid sending a
+  //redundant response
+  var responseIsSent = false;
+  
+  if (!fs.existsSync(fullPath)) {
+    res.status(400);
+    responseIsSent = true;
+    return res.send('No job with that ID.');
     
-    if (!fs.existsSync(fullPath)) {
-        res.status(400);
-        responseIsSent = true;
-        return res.send('No job with that ID.');
-        
-    }else if (!fs.existsSync(obabelOutputFilePath)) {
-        res.status(300);
-        responseIsSent = true;
-        return res.send('Job still processing.');
-        
-    } else {
+  }else if (!fs.existsSync(obabelOutputFilePath)) {
+    res.status(300);
+    responseIsSent = true;
+    return res.send('Job still processing.');
+      
+  } else {
+
+    var outputPath = path.join(uploadsPath, jobId + '.zip');
+    var output = fs.createWriteStream(outputPath);
     
-        var outputPath = path.join(uploadsPath, jobId + '.zip');
-        var output = fs.createWriteStream(outputPath);
-        var archive = archiver('zip', {
-            zlib: { level: 9 }
-        })
-        output.on('close', function () {
-            var stat = fs.statSync(outputPath);
-            if(!responseIsSent){
-                res.writeHead(200, {
-                    'Content-Type': 'application/zip',
-                    'Content-Length': stat.size
-                });
-                var readStream = fs.createReadStream(outputPath);
-                readStream.pipe(res)
-            }
-        })
-        archive.on('error', function (err) {
-            if(!responseIsSent){
-                res.status(500);
-                console.log(err)
-                responseIsSent = true;
-                return res.send('File archiving error.');
-            }
-        })
-        archive.pipe(output)
-        console.log(jobId);
-        try{
-            archive.directory(fullPath, "", { name: jobId })
-            archive.finalize();
-        } catch(error) {
-            console.log(error)
-        }
+    var archive = archiver('zip', {
+      zlib: { level: 9 }
+    })
+    
+    output.on('close', function () {
+      var stat = fs.statSync(outputPath);
+      if(!responseIsSent){
+        res.writeHead(200, {
+          'Content-Type': 'application/zip',
+          'Content-Length': stat.size
+        });
+        var readStream = fs.createReadStream(outputPath);
+        readStream.pipe(res)
+      }
+    })
+    
+    archive.on('error', function (err) {
+      if(!responseIsSent){
+        res.status(500);
+        console.log(err)
+        responseIsSent = true;
+        return res.send('File archiving error.');
+      }
+    })
+    
+    archive.pipe(output)
+    console.log(jobId);
+    
+    try{
+      archive.directory(fullPath, "", { name: jobId })
+      archive.finalize();
+    } catch(error) {
+      console.log(error)
     }
+  }
 });
 
 app.post('/v1/obabel', (req, res) => {
-    molecules = []
-    fields = {}
+  
+  molecules = []
+  fields = {}
+  
+  var responseIsSent = false;
+  var form = new formidable.IncomingForm();
+  
+  form.multiples = true;
+  form.parse(req);
+  form.on('field', function(name, value) {
+    fields[name] = value
+  })
+  
+  //create a random name for the directory
+  let nameHash = crypto.createHmac('sha1', crypto.randomBytes(48))
+    .update(Date.now()
+    .toString())
+    .digest('hex');
     
-    var responseIsSent = false;
-    var form = new formidable.IncomingForm();
-    form.multiples = true;
-    form.parse(req);
-    form.on('field', function(name, value) {
-        fields[name] = value
-    })
-    //create a random name for the directory
-    let nameHash = crypto.createHmac('sha1', crypto.randomBytes(48))
-        .update(Date.now()
-        .toString())
-        .digest('hex');
-    let directoryPath = path.join(__dirname,'uploads', nameHash)
-    let uploadsPath = path.join(__dirname,'uploads')
-    
-    
-    //Check for naming collisions
-    if (!fs.existsSync(directoryPath)) {
-        //create the new directory
-        fs.mkdirSync(directoryPath);
+  let directoryPath = path.join(__dirname,'uploads', nameHash)
+  let uploadsPath = path.join(__dirname,'uploads')
+  
+  //Check for naming collisions
+  if (!fs.existsSync(directoryPath)) {
+    //create the new directory
+    fs.mkdirSync(directoryPath);
+  }
+  else if(!responseIsSent) {
+    res.status(500);
+    res.send("Storage Error. Please try again.");
+    responseIsSent = true;
+  }
+  
+  form.on('fileBegin', function (name, file){
+    //each field in the form whose name starts with "molecule"
+    if (name.startsWith('molecule')) {
+      molecule = {}
+      molecule.name = file.name
+      molecules.push(molecule)
     }
-    else if(!responseIsSent) {
-        res.status(500);
-        res.send("Storage Error. Please try again.");
-        responseIsSent = true;
-    }
+
+    fullPath = path.join(directoryPath, file.name);
+    file.path = fullPath;
+  });
+  form.on('end', function() {
+    try {
+      //arguments for openbabel
+      var args = []
+      var options = [] 
     
-    form.on('fileBegin', function (name, file){
+      //does not include -i tag if the value of toPDB is true (so the molecules are combined in one file)
+      if(!('toPDB' in fields) || !(fields['toPDB'] == "true")){
+        //set the input file type to pdb (the default option)
+        args.push('-ipdb');
+      }
+      
+      for(molecule of molecules){
+        molecule_path = path.join(directoryPath,molecule.name )
+        args.push('"' + molecule_path + '"');
+      }
+    
+      //does not include -o tag if the value of toPDB is true (so the molecules are combined in one file)
+      if(!('toPDB' in fields) || !(fields['toPDB'])){
+        //set the output file type to pdbqt (This is the default behavior)
+        args.push('-opdbqt');
+      }
+      
+      var outputFilePath = '';
+      if('toPDB' in fields && fields['toPDB']){
+        //set the output file type to pdb
+        outputFilePath = path.join(directoryPath,'result.pdb')
+      }else{
+        //set the output file type to pdbqt (This is the default behavior)
+        outputFilePath = path.join(directoryPath,'result.pdbqt')
+      }
+      
+      args.push(`-O${outputFilePath}`);
+      
+      try {
+        obable_program = path.join(__dirname, "obabel");
+
+        options = {};
+        options.shell = true;
         
-        //each field in the form whose name starts with "molecule"
-        if (name.startsWith('molecule')) {
-            molecule = {}
-            molecule.name = file.name
-            molecules.push(molecule)
-        }
-
-        fullPath = path.join(directoryPath, file.name);
-        file.path = fullPath;
-    });
-    form.on('end', function() {
-        try {
-            //arguments for openbabel
-            var args = []
-            var options = [] 
-			
-			//does not include -i tag if the value of toPDB is true (so the molecules are combined in one file)
-			if(!('toPDB' in fields) || !(fields['toPDB'] == "true")){
-				//set the input file type to pdb (the default option)
-				args.push('-ipdb');
-			}
-            for(molecule of molecules){
-                
-                molecule_path = path.join(directoryPath,molecule.name )
-                
-                args.push('"' + molecule_path + '"');
-                
-            }
-			
-			//does not include -o tag if the value of toPDB is true (so the molecules are combined in one file)
-			if(!('toPDB' in fields) || !(fields['toPDB'])){
-				//set the output file type to pdbqt (This is the default behavior)
-				args.push('-opdbqt');
-			}
-			
-			var outputFilePath = '';
-			if('toPDB' in fields && fields['toPDB']){
-				//set the output file type to pdb
-				outputFilePath = path.join(directoryPath,'result.pdb')
-			}else{
-				//set the output file type to pdbqt (This is the default behavior)
-				outputFilePath = path.join(directoryPath,'result.pdbqt')
-			}
-			args.push(`-O${outputFilePath}`);
-            
-            try {
-                obable_program = path.join(__dirname, "obabel");
-
-                options = {};
-                options.shell = true;
-                
-				console.log(args.toString())
-				
-                //execute the obabel binary
-                exec("obabel " + args.join(' '), options, function(error, stdout, stderr) {
-                    
-                    callback = (error) => {
-                        if(!responseIsSent) {
-                            res.status(500)
-                            res.send('Execution error: ' + error)
-                            responseIsSent = true;
-                        }
-                        
-                    }
-                    outputTextPath = path.join(directoryPath,'obabel-output.txt')
-                    fs.writeFile(outputTextPath, stdout, callback)
-                    fs.appendFile(outputTextPath, stderr, callback)
-                    fs.appendFile(outputTextPath, error, callback)
-                });
-                if(!responseIsSent) {
-                    res.status(200)
-                    res.send(nameHash)
-                    responseIsSent = true;
-                }
-                
-            }
-            catch(error) {
-                //avoid double-sending
-                if(!responseIsSent) {
-                    res.status(500)
-                    res.send('Execution error: ' + error)
-                    responseIsSent = true;
-                }
-            }
-        }
-        catch(err) {
-            //avoid double-sending
+        console.log(args.toString())
+        
+        //execute the obabel binary
+        exec("obabel " + args.join(' '), options, function(error, stdout, stderr) {
+          callback = (error) => {
             if(!responseIsSent) {
-                res.status(400)
-                res.send('Incorrect arguments provided.')
-                responseIsSent = true;
-            }
-        }    
-    })
+              res.status(500)
+              res.send('Execution error: ' + error)
+              responseIsSent = true;
+            }            
+          }
+          outputTextPath = path.join(directoryPath,'obabel-output.txt')
+          fs.writeFile(outputTextPath, stdout, callback)
+          fs.appendFile(outputTextPath, stderr, callback)
+          fs.appendFile(outputTextPath, error, callback)
+        });
+        
+        if(!responseIsSent) {
+          res.status(200)
+          res.send(nameHash)
+          responseIsSent = true;
+        }
+        
+      }
+      catch(error) {
+        //avoid double-sending
+        if(!responseIsSent) {
+          res.status(500)
+          res.send('Execution error: ' + error)
+          responseIsSent = true;
+        }
+      }
+    }
+    catch(err) {
+      //avoid double-sending
+      if(!responseIsSent) {
+        res.status(400)
+        res.send('Incorrect arguments provided.')
+        responseIsSent = true;
+      }
+    }    
+  })
 });
 
 app.listen(8000, () => {
-    console.log('Listening on port 8000.')
+  console.log('Listening on port 8000.')
 })


### PR DESCRIPTION
Containerized Open Babel installation now:

 - appropriately returns all result files in the returned zip file
 - names returned files that resulted from the conversion "result.[file extension]"
 - converts files to .pdb format from .pdbqt if the "toPDB" field is filled as "true"
 - combines a .pdb macromolecule and .pdbqt ligand file that resulted from a docking operation if the "toPDB" field is filled as true
 - retains original functionality when no "toPDB" field is given