### PR TITLE
Mol 63 updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:19.10
 
 # Update Ubuntu Software Repo and install curl
 RUN apt-get update && apt-get install curl --yes

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Request body parameters
 | Parameter | Type | Function |
 |:----------|:-----|:---------|
 | molecule_n | form data | A file to be converted. A .pdbqt file is expected, and will be converted to a .pdb file. Note that any number of molecules can be given, keyed "molecule_1," "molecule_2," etc. If a ligand and a macromolecule are given, they will be combined into a single output file|
+| options | form data | String of additional options to pass to OpenBabel at runtime. Optional. |
 
 Output
 
@@ -79,6 +80,7 @@ Request body parameters
 | Parameter | Type | Function |
 |:----------|:-----|:---------|
 | molecule_n | form data | A file to be converted. By default a .pdb file is expected, and will be converted to a .pdbqt file. Note that any number of molecules can be given, keyed "molecule_1," "molecule_2," etc.|
+| options | form data | String of additional options to pass to OpenBabel at runtime. Optional. |
 
 Output
 

--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ app.get('/v1/obabel', (req, res) => {
 });
 
 app.post('/v1/obabel/toPDBQT', (req, res) => {
-  return openbabelFileConversion(req, res,'result.pdbqt',["-xr"])
+  return openbabelFileConversion(req, res,'result.pdbqt')
 });
 
 app.post('/v1/obabel/toPDB', (req, res) => {
@@ -172,9 +172,12 @@ function openbabelFileConversion(req, res, outputName, options = [], inputFileTy
       args.push(`-O${outputFilePath}`);
       
       //add all specified options to the command
-      for(let option in options){
+      for(option of options){
         args.push(option);
       }
+	  
+	  if(fields.options)
+		args.push(fields.options);
 
       try {
         obable_program = path.join(__dirname, "obabel");


### PR DESCRIPTION
Updates the version of Ubuntu used by the docker container. 
- There is an issue with the version of OpenBabel distributed for Ubuntu 18.04 that causes a ROOT tag to be added to pdbqt files when generating a rigid structure. This caused AutoDock Vina to fail with any files that originally had multiple torsion trees, such as 1A0J. Bumping the version of Ubuntu to 19.10 installs a newer version of OpenBabel with that bug fixed.

Allows entering options for POST requests
- To avoid needing logic to handle if a file is a ligand or not when converting to pdbqt, which would need to be generated without the -xr option, provides the ability for an options string to be provided.